### PR TITLE
pooldrop Whitelist Restriction implementation and validations

### DIFF
--- a/backend/src/HttpHandler.ts
+++ b/backend/src/HttpHandler.ts
@@ -138,7 +138,7 @@ export class HttpHandler implements LambdaHttpHandler {
 
     async createLinkAndRegister(req: JsonRpcRequest): Promise<PoolDrop> {
         const {token, totalAmount, numberOfParticipants,
-            participationAmountFormatted, completedMessage, completedLink } = req.data;
+            participationAmountFormatted, completedMessage, completedLink,restrictedParticipants } = req.data;
         validateFieldsRequired({token, totalAmount, numberOfParticipants,
             participationAmountFormatted});
         ValidationUtils.isTrue(Big(totalAmount).gt(Big(0)), "Amount must be greater than zero");
@@ -164,6 +164,7 @@ export class HttpHandler implements LambdaHttpHandler {
             completedLink,
             completedMessage,
             transactionIds: [],
+            restrictedParticipants
         } as PoolDrop;
         return this.userSvc.createLinkAndRegister(token, link);
     }

--- a/backend/src/MongoTypes.ts
+++ b/backend/src/MongoTypes.ts
@@ -4,6 +4,7 @@ import { PoolDrop, PoolDropClaim } from "./Types";
 
 const claimSchema: Schema = new Schema<PoolDropClaim>({
     address: String,
+    email: String,
     userId: String,
 });
 
@@ -25,6 +26,7 @@ const poolDropSchema: Schema = new Schema<PoolDrop>({
     executed: Boolean,
     completedLink: String,
     completedMessage: String,
+    restrictedParticipants: String
 });
 
 export const PoolDropModel = (c: Connection) => c.model<PoolDrop&Document>('poolDrops', poolDropSchema);

--- a/backend/src/Types.ts
+++ b/backend/src/Types.ts
@@ -4,6 +4,7 @@ import { MongooseConfig } from "aws-lambda-helper";
 export interface PoolDropClaim {
     address: string;
     userId: string;
+    email?: string;
 }
 
 export interface PoolDrop {
@@ -26,6 +27,7 @@ export interface PoolDrop {
     transactionIds: string[];
     completedMessage?: string;
     completedLink?: string;
+    restrictedParticipants?: string
 }
 
 export interface PoolDropConfig {

--- a/frontend/src/common/RootState.ts
+++ b/frontend/src/common/RootState.ts
@@ -25,6 +25,8 @@ export interface PoolDropCreateState {
     completedMessage: string;
     completedLink: string;
     error?: string;
+    whiteListedEmails: string;
+    showWhiteListedEmails: boolean;
 }
 
 export interface RootState {

--- a/frontend/src/common/Types.ts
+++ b/frontend/src/common/Types.ts
@@ -3,6 +3,7 @@ import { Network } from "ferrum-plumbing";
 export interface PoolDropClaim {
     address: string;
     userId: string;
+    email?: string
 }
 
 export interface PoolDrop {
@@ -24,4 +25,5 @@ export interface PoolDrop {
     transactionIds: string[];
     completedMessage?: string;
     completedLink?: string;
+    restrictedParticipants?: string
 }

--- a/frontend/src/common/Utils.ts
+++ b/frontend/src/common/Utils.ts
@@ -38,4 +38,31 @@ export class Utils {
             `https://rinkeby.etherscan.io/tx/${tid}` :
             `https://etherscan.io/tx/${tid}`;
     }
+
+    static validateMultipleEmails (emailInput: any) {
+        // Get value on emails input as a string
+        let emails = emailInput;
+        
+        // Split string by comma into an array
+        emails = emails.split(",");
+    
+        const valid = true;
+        const regex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+        
+        const invalidEmails = [];
+        const validEmails = [];
+        
+        for (var i = 0; i < emails.length; i++) {
+            // Trim whitespaces from email address
+            emails[i] = emails[i].trim();
+            
+            // Check email against our regex to determine if email is valid
+            if( emails[i] == "" || ! regex.test(emails[i])){
+                invalidEmails.push(emails[i]);
+            }else{
+                validEmails.push(emails[i])
+            }
+        }
+        return {emails,invalidEmails,validEmails};
+    }     
 }

--- a/frontend/src/pages/claim/ClaimContainer.tsx
+++ b/frontend/src/pages/claim/ClaimContainer.tsx
@@ -87,7 +87,7 @@ function ClaimComponent(props: ClaimProps&ClaimDispatch) {
                 </Row>
             </>
         );
-    } else if (props.filled && !props.isOwner) {
+    } else if (props.filled && !props.isOwner && !props.alreadyClaimed) {
         details = (
             <>
                 <Row withPadding centered>
@@ -136,6 +136,22 @@ function ClaimComponent(props: ClaimProps&ClaimDispatch) {
                             value={intl('claimed-out-of', {count: props.claimedCount, total: props.claimedTotal})}
                             disabled={true}
                         />
+                    </Row>
+                    <Row withPadding center>
+                        <ThemedText.H3>{'Claimed Users'}</ThemedText.H3>
+                    </Row>
+                    <Row withPadding>
+                        {
+                            (props.claimedCount > 0) &&
+                            props.claimed.map(
+                                (e:any) => (
+                                    <InputGroupAddon
+                                        value={e.email}
+                                        disabled={true}
+                                    />
+                                )
+                            )
+                        }
                     </Row>
                     <Row withPadding center>
                         <ThemedText.H3>{intl('pool-drop-link')}</ThemedText.H3>

--- a/frontend/src/pages/poolDropCreate/PoolDropCreateContainer.tsx
+++ b/frontend/src/pages/poolDropCreate/PoolDropCreateContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PoolDropCreateProps, PoolDropCreateDispatch, PoolDropCreate } from './PoolDropCreate';
 import {
-    Page, PageTopPart, Row, Gap, ThemedText, ThemedButton, InputGroupAddon, ErrorMessage,
+    Page, PageTopPart, Row, Gap, ThemedText, ThemedButton, InputGroupAddon, ErrorMessage,Checkbox
     // @ts-ignore
 } from 'unifyre-web-components';
 import { intl } from 'unifyre-react-helper';
@@ -87,6 +87,18 @@ function PoolDropCreateComponent(props: PoolDropCreateProps&PoolDropCreateDispat
                     onChange={props.onCompletedLinkChanged}
                 />
             </Row>
+            <Checkbox leftLabel={'WhiteList Emails (Restrict Participants)'} onChange={props.onWhiteListChecked}/>
+            {
+                props.showWhiteListedEmails &&
+                <>
+                    <Row withPadding>
+                        <ThemedText.SMALL>{'Participant Emails (Comma seperated)'}</ThemedText.SMALL>
+                    </Row>
+                    <Row withPadding>
+                        <InputGroupAddon value={props.whiteListedEmails} onChange={props.onWhiteListedEmailChanged}/>
+                    </Row>
+                </>
+            }
             {error}
             <Row withPadding>
                 <ThemedButton text={intl('create-link')} onClick={() => props.onCreate(history, props)} />

--- a/frontend/src/services/PoolDropClient.ts
+++ b/frontend/src/services/PoolDropClient.ts
@@ -16,7 +16,7 @@ export const PoolDropServiceActions = {
     AUTHENTICATION_COMPLETED: 'AUTHENTICATION_COMPLETED',
     USER_DATA_RECEIVED: 'USER_DATA_RECEIVED',
     ACTIVE_POOLDROPS_RECEIVED: 'ACTIVE_POOLDROPS_RECEIVED',
-
+    ONCHANGE_WHITE_LISTED_EMAILS: 'ONCHANGE_WHITE_LISTED_EMAILS',
     POOL_DROP_RECEIVED: 'POOL_DROP_RECEIVED',
     POOL_DROP_RECEIVE_FAILED: 'POOL_DROP_RECEIVE_FAILED',
     CLAIM_FAILED: 'CLAIM_FAILED',
@@ -66,6 +66,7 @@ export class PoolDropClient implements Injectable {
         numberOfParticipants: number,
         completedMessage?: string,
         completedLink?: string,
+        restrictedParticipants?: string
     ): Promise<PoolDrop|undefined> {
         try {
             ValidationUtils.isTrue(!!currency, "'currency' is required");
@@ -89,6 +90,7 @@ export class PoolDropClient implements Injectable {
                     participationAmountFormatted,
                     completedMessage,
                     completedLink,
+                    restrictedParticipants
                 }, params: [] } as JsonRpcRequest);
             if (!poolDrop) {
                 dispatch(addAction(Actions.CREATE_POOL_DROP_FAILED, { message: 'Could not connect to Unifyre' }));


### PR DESCRIPTION
# What does this PR do?

On the claim page:

1. Your email is in the whitelist -> Claim as usual
2. You don't have an email -> Show error: This is a whitelisted pool drop. You need to have a verified email in Unifyre to claim this pool drop.
3. You have email but the email is not in the white list: Show error: This is a whitelisted pool drop. Your email is not in the white list.
4. At the owner view, (if you are the owner of pooldrop) show list of emails already claimed.

Data changes:
One extra fields on a pooldrop:
1. Whitelisted emails: One string (emails comma separated)
One modification on data:
2. The array of claims should include email in addition to userId and address

Logic change:
1. On the backend before claiming, double check user email is in the white list
2. On the backend store the whitelist when creating
3. On the backend after claim, add user email to the claimed list.